### PR TITLE
[bugfix] Fixes property definitions and computed helper

### DIFF
--- a/addon/compatibility.js
+++ b/addon/compatibility.js
@@ -2,18 +2,30 @@ import { computed as emberComputed } from '@ember/object';
 
 import { SUPPORTS_NEW_COMPUTED } from 'ember-compatibility-helpers';
 
-export function computed(desc) {
-  if (SUPPORTS_NEW_COMPUTED || typeof desc === 'function') {
-    return emberComputed(desc);
-  } else {
-    const { get, set } = desc;
+let computed;
 
-    return emberComputed(function (key, value) {
-      if (arguments.length > 1) {
-        return set.call(this, key, value);
-      }
+if (SUPPORTS_NEW_COMPUTED) {
+  computed = emberComputed;
+} else {
+  computed = function(...params) {
+    let desc = params.pop();
 
-      return get.call(this);
-    });
-  }
+    if (typeof desc === 'function') {
+      return emberComputed(...params, desc);
+    } else if ('set' in desc) {
+      const { get, set } = desc;
+
+      return emberComputed(...params, function (key, value) {
+        if (arguments.length > 1) {
+          return set.call(this, key, value);
+        }
+
+        return get.call(this);
+      });
+    } else {
+      return emberComputed(...params, desc.get);
+    }
+  };
 }
+
+export { computed };

--- a/addon/computed.js
+++ b/addon/computed.js
@@ -23,7 +23,12 @@ export function computedDecorator(fn) {
     if (HAS_NATIVE_COMPUTED_GETTERS) {
       Ember.defineProperty(target, key, computedDesc);
     } else {
-      Object.defineProperty(target, key, { value: computedDesc });
+      Object.defineProperty(target, key, {
+        configurable: true,
+        writable: true,
+        enumerable: true,
+        value: computedDesc
+      });
     }
 
     // There's currently no way to disable redefining the property when decorators

--- a/tests/unit/compatibility-helpers-test.js
+++ b/tests/unit/compatibility-helpers-test.js
@@ -1,0 +1,42 @@
+import EmberObject from '@ember/object';
+import { module, test } from 'qunit';
+import { computed } from '@ember-decorators/utils/compatibility';
+
+module('compatibility helpers', function() {
+
+  module('computed', function() {
+
+    test('can use new syntax', function(assert) {
+      let foo = EmberObject.extend({
+        bar: computed({
+          get() {
+            assert.ok(true, 'getter called correctly');
+          },
+
+          set(key, value) {
+            assert.equal(value, 'baz', 'setter called with correct value');
+          }
+        })
+      }).create();
+
+      foo.get('bar');
+      foo.set('bar', 'baz');
+    });
+
+    test('dependent keys passed correctly to computed', function(assert) {
+      let foo = EmberObject.extend({
+        foo: 123,
+
+        bar: computed('foo', {
+          get() {
+            return this.get('foo');
+          }
+        })
+      }).create();
+
+      assert.equal(foo.get('bar'), 123);
+      foo.set('foo', 456);
+      assert.equal(foo.get('bar'), 456);
+    });
+  });
+});


### PR DESCRIPTION
1. Computed properties depend on being writable properties (specifically
macros like `oneWay` and `reads`).

2. Computed helper didn't accept dependent keys 🙃 