### PR TITLE
[bugfix] always do Ember.defineProperty

### DIFF
--- a/addon/computed.js
+++ b/addon/computed.js
@@ -20,16 +20,19 @@ export function computedDecorator(fn) {
 
     assert(`computed decorators must return an instance of an Ember ComputedProperty descriptor, received ${computedDesc}`, isComputedDescriptor(computedDesc));
 
-    if (HAS_NATIVE_COMPUTED_GETTERS) {
-      Ember.defineProperty(target, key, computedDesc);
-    } else {
+    if (!HAS_NATIVE_COMPUTED_GETTERS) {
+      // Until recent versions of Ember, computed properties would be defined
+      // by just setting them. We need to blow away any predefined properties
+      // (getters/setters, etc.) to allow Ember.defineProperty to work correctly.
       Object.defineProperty(target, key, {
         configurable: true,
         writable: true,
         enumerable: true,
-        value: computedDesc
+        value: undefined
       });
     }
+
+    Ember.defineProperty(target, key, computedDesc);
 
     // There's currently no way to disable redefining the property when decorators
     // are run, so return the property descriptor we just assigned

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "@ember-decorators/babel-transforms": "^0.1.1",
     "ember-cli-babel": "^6.6.0",
     "ember-compatibility-helpers": "1.0.0-beta.1"
   },
   "devDependencies": {
+    "@ember-decorators/babel-transforms": "^0.1.1",
     "@types/ember": "^2.8.9",
     "@types/ember-data": "^2.14.8",
     "@types/ember-test-helpers": "^0.7.0",


### PR DESCRIPTION
Certain libraries rely on Ember hooks when defining properties,
most notably EmberData. By always running Ember.defineProperty,
we can ensure that computed properties are always defined exactly
the same way as Ember does it by default.

Note that this still means that normal class props will not go
through this process. I think this is ultimately preferable, we
will likely want to drop this custom behavior as we can, but
this exception makes sense for the moment.